### PR TITLE
chore: add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+type: Bug
+---
+
+### Describe the bug
+
+A clear and concise description of what the bug is.
+
+### To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+### Logs / Screenshots
+
+If applicable, add logs or screenshots to help explain your problem.
+
+### Software versions
+
+- Gangplank version: [e.g. v0.5.0, or container image tag]
+- Kubernetes version: [e.g. 1.31.1]
+- OIDC provider: [e.g. Dex, Keycloak, Okta, etc.]
+- Deployment method: [e.g. Helm chart, Kubernetes manifests]
+- Browser (if UI-related): [e.g. Chrome 130, Firefox 132]
+
+### Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+type: Feature
+---
+
+### Is your feature request related to a problem? Please describe
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+### Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+### Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,69 @@
+<!--
+Thank you for contributing to this project! You must fill out the information below before we can review this pull request.
+By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
+request to the best possible team for review.
+
+💡 **TIP**
+Remember that you can always open a PR in draft status and fill all the information afterward.
+
+Opening a PR in draft allows other team members to know that you are working on this change and lets you have a 
+place to track your work in progress.
+
+When opening PRs in Draft, don't assign reviewers until the PR is ready for review. Once you are comfortable with the
+status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
+-->
+
+### Summary 💡
+
+<!-- Write a short summary of the changes that this PR introduces and the motivations -->
+
+<!--
+If there's an existing issue for your change, please link to it below inserting a link or the issue number.
+If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
+for example, is an error message that other users could get and google it.
+-->
+Closes:
+
+
+<!-- If this PR is related to changes produced in other repos, like a Module or the distribution, please link them below. -->
+Relates:
+
+
+### Description 📝
+
+<!--
+Let us know what you are changing. Share anything that could provide the most context.
+Feel free to add screenshots or code examples. The Description could end up in the release notes to help users adopt
+the new features or changes you are introducing.
+
+Expand on the reasoning behind some decision that you could have made to help reviewers understand the diff in the PR.
+
+-->
+
+### Breaking Changes 💔
+
+<!--
+If this PR introduces Breaking Changes, please include all the relevant information:
+- What is changing
+- What should the process for updating be
+- Include examples if you can
+-->
+
+### Tests performed 🧪
+
+<!--
+Create a checklist with all the tests that you performed on your changes, being manual or automated.
+If you are opening a Draft PR, you can use the checklist to track the tests that you want to do and mark them once you
+have performed them.
+Example:
+
+- [ ] Test Suite Execution: Ran all unit, integration, and E2E tests.
+- [ ] Local Verification: Validated functionality within the local development environment.
+-->
+
+### Future work 🔧
+
+<!--
+If there's any future work that could improve or extend on the work you've done in this PR you can mention it so
+this PR can be used as context for that.
+-->


### PR DESCRIPTION
This PR is the continuation of the PR https://github.com/sighupio/gangplank/pull/17
Closes #16 

The objective is to add GitHub templates to standardize contributions and issues structure.

Starting from templates in  https://github.com/sighupio/furyctl/blob/main/.github:
- In `pull_request_template.md`, changed the two "Tests performed" examples
- In `bug_report.md`, changed "software-versions" block
- `feature_request.md` kept like the original