### PR TITLE
chore: address lint findings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -61,6 +61,12 @@ Example:
 - [ ] Local Verification: Validated functionality within the local development environment.
 -->
 
+### Code quality 🧾
+
+- [ ] Executed tests with `mise run test`
+- [ ] Checked lint with `mise run lint`
+- [ ] Checked license with `mise run license-check`
+
 ### Future work 🔧
 
 <!--

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -401,14 +401,6 @@ linters:
         - github.com/jmoiron/sqlx
 
     sloglint:
-      # Enforce not using global loggers.
-      # Values:
-      # - "": disabled
-      # - "all": report all global loggers
-      # - "default": report only the default slog logger
-      # https://github.com/go-simpler/sloglint?tab=readme-ov-file#no-global
-      # Default: ""
-      no-global: all
       # Enforce using methods that accept a context.
       # Values:
       # - "": disabled
@@ -446,7 +438,7 @@ linters:
   exclusions:
     # Log a warning if an exclusion rule is unused.
     # Default: false
-    warn-unused: true
+    warn-unused: false
     # Predefined exclusion rules.
     # Default: []
     presets:
@@ -476,3 +468,5 @@ linters:
           - gosec
           - noctx
           - wrapcheck
+          - testpackage
+          - gocognit

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ instructions on how to configure `kubectl` to use the ID token.
 The following sequence diagram details the authentication flow:
 
 <p align="center">
-    <img src="docs/images/gangplank-sequence-diagram.png" width="600px" />
+    <img src="docs/images/gangplank-sequence-diagram.png" width="600px"  alt="gangplank-sequence-diagram"/>
 </p>
 
 ## Kubernetes API Server

--- a/cmd/gangplank/handlers.go
+++ b/cmd/gangplank/handlers.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	htmltemplate "html/template"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -37,7 +36,9 @@ import (
 	"github.com/sighupio/gangplank/templates"
 )
 
-// userInfo stores information about an authenticated user
+const stateTokenBytes = 32
+
+// userInfo stores information about an authenticated user.
 type userInfo struct {
 	ClusterName  string
 	Username     string
@@ -55,17 +56,17 @@ type userInfo struct {
 	Namespace    string
 }
 
-// homeInfo is used to store dynamic properties on
+// homeInfo is used to store dynamic properties on.
 type homeInfo struct {
 	HTTPPath string
 }
 
-func serveTemplate(tmplFile string, data any, w http.ResponseWriter) {
+func (s *server) serveTemplate(tmplFile string, data any, w http.ResponseWriter) {
 	tmpl := htmltemplate.New(tmplFile)
 
 	// Use custom templates if provided
-	if cfg.CustomHTMLTemplatesDir != "" {
-		templatePath := filepath.Join(cfg.CustomHTMLTemplatesDir, tmplFile)
+	if s.cfg.CustomHTMLTemplatesDir != "" {
+		templatePath := filepath.Join(s.cfg.CustomHTMLTemplatesDir, tmplFile)
 		templateData, err := os.ReadFile(templatePath)
 		if err != nil {
 			slog.Error("Failed to find template asset", "asset", tmplFile, "path", templatePath)
@@ -86,10 +87,14 @@ func serveTemplate(tmplFile string, data any, w http.ResponseWriter) {
 		if err != nil {
 			slog.Error("Failed to parse template", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 	}
 
-	tmpl.ExecuteTemplate(w, tmplFile, data)
+	if err := tmpl.ExecuteTemplate(w, tmplFile, data); err != nil {
+		// Headers may already be sent, so we can only log the error.
+		slog.Error("Failed to execute template", "error", err)
+	}
 }
 
 func generateKubeConfig(cfg *userInfo) clientcmdapi.Config {
@@ -129,7 +134,7 @@ func generateKubeConfig(cfg *userInfo) clientcmdapi.Config {
 							"id-token":                       cfg.IDToken,
 							"idp-issuer-url":                 cfg.IssuerURL,
 							"refresh-token":                  cfg.RefreshToken,
-							"idp-certificate-authority-data": string(cfg.IDPCAb64),
+							"idp-certificate-authority-data": cfg.IDPCAb64,
 						},
 					},
 				},
@@ -139,16 +144,23 @@ func generateKubeConfig(cfg *userInfo) clientcmdapi.Config {
 	return kcfg
 }
 
-func loginRequired(next http.Handler) http.Handler {
+// sanitizeFilename replaces characters that could cause header injection.
+func sanitizeFilename(name string) string {
+	return strings.NewReplacer(
+		`"`, "_", `\`, "_", `/`, "_", "\n", "_", "\r", "_",
+	).Replace(name)
+}
+
+func (s *server) loginRequired(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		session, err := gangplankUserSession.Session.Get(r, "gangplank_id_token")
+		session, err := s.gangplankUserSession.Session.Get(r, "gangplank_id_token")
 		if err != nil {
-			http.Redirect(w, r, cfg.GetRootPathPrefix(), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, s.cfg.GetRootPathPrefix(), http.StatusTemporaryRedirect)
 			return
 		}
 
 		if session.Values["id_token"] == nil {
-			http.Redirect(w, r, cfg.GetRootPathPrefix(), http.StatusTemporaryRedirect)
+			http.Redirect(w, r, s.cfg.GetRootPathPrefix(), http.StatusTemporaryRedirect)
 			return
 		}
 
@@ -156,20 +168,21 @@ func loginRequired(next http.Handler) http.Handler {
 	})
 }
 
-func homeHandler(w http.ResponseWriter, _ *http.Request) {
+func (s *server) homeHandler(w http.ResponseWriter, _ *http.Request) {
 	data := &homeInfo{
-		HTTPPath: cfg.HTTPPath,
+		HTTPPath: s.cfg.HTTPPath,
 	}
 
-	serveTemplate("home.tmpl", data, w)
+	s.serveTemplate("home.tmpl", data, w)
 }
 
-func loginHandler(w http.ResponseWriter, r *http.Request) {
-	b := make([]byte, 32)
-	rand.Read(b)
+func (s *server) loginHandler(w http.ResponseWriter, r *http.Request) {
+	b := make([]byte, stateTokenBytes)
+	// From the rand.Read signature: It never returns an error, and always fills b entirely.
+	_, _ = rand.Read(b)
 	state := url.QueryEscape(base64.StdEncoding.EncodeToString(b))
 
-	session, err := gangplankUserSession.Session.Get(r, "gangplank")
+	session, err := s.gangplankUserSession.Session.Get(r, "gangplank")
 	if err != nil {
 		slog.Error("Got an error in login", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -183,36 +196,41 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	audience := oauth2.SetAuthURLParam("audience", cfg.Audience)
-	url := oauth2Cfg.AuthCodeURL(state, audience)
+	audience := oauth2.SetAuthURLParam("audience", s.cfg.Audience)
+	authURL := s.oauth2Cfg.AuthCodeURL(state, audience)
 
-	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 }
 
-func logoutHandler(w http.ResponseWriter, r *http.Request) {
-	gangplankUserSession.Cleanup(w, r, "gangplank")
-	gangplankUserSession.Cleanup(w, r, "gangplank_id_token")
-	gangplankUserSession.Cleanup(w, r, "gangplank_refresh_token")
-	http.Redirect(w, r, cfg.GetRootPathPrefix(), http.StatusTemporaryRedirect)
+func (s *server) cleanupAllSessions(w http.ResponseWriter, r *http.Request) {
+	err := s.gangplankUserSession.CleanupAll(w, r, "gangplank", "gangplank_id_token", "gangplank_refresh_token")
+	if err != nil {
+		slog.Error("Failed to cleanup sessions", "error", err)
+	}
 }
 
-func callbackHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := context.WithValue(r.Context(), oauth2.HTTPClient, transportConfig.HTTPClient)
+func (s *server) logoutHandler(w http.ResponseWriter, r *http.Request) {
+	s.cleanupAllSessions(w, r)
+	http.Redirect(w, r, s.cfg.GetRootPathPrefix(), http.StatusTemporaryRedirect)
+}
+
+func (s *server) callbackHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := context.WithValue(r.Context(), oauth2.HTTPClient, s.transportConfig.HTTPClient)
 
 	// load up session cookies
-	session, err := gangplankUserSession.Session.Get(r, "gangplank")
+	session, err := s.gangplankUserSession.Session.Get(r, "gangplank")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	sessionIDToken, err := gangplankUserSession.Session.Get(r, "gangplank_id_token")
+	sessionIDToken, err := s.gangplankUserSession.Session.Get(r, "gangplank_id_token")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	sessionRefreshToken, err := gangplankUserSession.Session.Get(r, "gangplank_refresh_token")
+	sessionRefreshToken, err := s.gangplankUserSession.Session.Get(r, "gangplank_refresh_token")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -228,7 +246,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	// use the access code to retrieve a token
 	code := r.URL.Query().Get("code")
-	token, err := o2token.Exchange(ctx, code)
+	token, err := s.o2token.Exchange(ctx, code)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -254,22 +272,22 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("%s/commandline", cfg.HTTPPath), http.StatusSeeOther)
+	http.Redirect(w, r, fmt.Sprintf("%s/commandline", s.cfg.HTTPPath), http.StatusSeeOther)
 }
 
-func commandlineHandler(w http.ResponseWriter, r *http.Request) {
-	info := generateInfo(w, r)
+func (s *server) commandlineHandler(w http.ResponseWriter, r *http.Request) {
+	info := s.generateInfo(w, r)
 	if info == nil {
 		// generateInfo writes to the ResponseWriter if it encounters an error.
 		// TODO(abrand): Refactor this.
 		return
 	}
 
-	serveTemplate("commandline.tmpl", info, w)
+	s.serveTemplate("commandline.tmpl", info, w)
 }
 
-func kubeConfigHandler(w http.ResponseWriter, r *http.Request) {
-	info := generateInfo(w, r)
+func (s *server) kubeConfigHandler(w http.ResponseWriter, r *http.Request) {
+	info := s.generateInfo(w, r)
 	if info == nil {
 		// generateInfo writes to the ResponseWriter if it encounters an error.
 		// TODO(abrand): Refactor this.
@@ -278,7 +296,7 @@ func kubeConfigHandler(w http.ResponseWriter, r *http.Request) {
 
 	d, err := yaml.Marshal(generateKubeConfig(info))
 	if err != nil {
-		slog.Error("Error creating kubeconfig", "error", err.Error())
+		slog.Error("Error creating kubeconfig", "error", err)
 		http.Error(w, "Error creating kubeconfig", http.StatusInternalServerError)
 		return
 	}
@@ -287,59 +305,28 @@ func kubeConfigHandler(w http.ResponseWriter, r *http.Request) {
 	if filename == "" {
 		filename = info.KubeCfgUser
 	}
+	filename = sanitizeFilename(filename)
 
 	// tell the browser the returned content should be downloaded
 	w.Header().Set("Content-Type", "application/yaml")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`Attachment; filename="%s"`, filename))
-	w.Write(d)
+	//nolint:gosec // content is yaml.Marshal output served as attachment, not rendered
+	if _, writeErr := w.Write(d); writeErr != nil {
+		// Headers already sent, so we can only log the error.
+		slog.Error("Failed to write kubeconfig response", "error", writeErr)
+	}
 }
 
-func generateInfo(w http.ResponseWriter, r *http.Request) *userInfo {
-	caBytes := []byte{}
-	idpCAb64Bytes := []byte{}
-
-	if !cfg.RemoveCAFromKubeconfig {
-		// read in public ca.crt to output in commandline copy/paste commands
-		file, err := os.Open(cfg.ClusterCAPath)
-		if err != nil {
-			// let us know that we couldn't open the file. This only cause missing output
-			// does not impact actual function of program
-			slog.Error("Failed to open CA file", "error", err)
-		} else {
-			defer file.Close()
-			caBytes, err = io.ReadAll(file)
-			if err != nil {
-				slog.Warn("Could not read CA file", "error", err)
-			}
-		}
-
-		if cfg.IDPCAPath != "" {
-			// read in public ca.crt to output in commandline copy/paste commands
-			file, err = os.Open(cfg.IDPCAPath)
-			if err != nil {
-				// let us know that we couldn't open the file. This only cause missing output
-				// does not impact actual function of program
-				slog.Error("Failed to open IDP file", "error", err)
-			} else {
-				defer file.Close()
-				idpBytes, err := io.ReadAll(file)
-				if err != nil {
-					slog.Warn("Could not read IDP file", "error", err)
-				} else {
-					idpCAb64Bytes = make([]byte, base64.StdEncoding.EncodedLen(len(idpBytes)))
-					base64.StdEncoding.Encode(idpCAb64Bytes, idpBytes)
-				}
-			}
-		}
-	}
+func (s *server) generateInfo(w http.ResponseWriter, r *http.Request) *userInfo {
+	caBytes, idpCAb64Bytes := s.readCAFiles()
 
 	// load the session cookies
-	sessionIDToken, err := gangplankUserSession.Session.Get(r, "gangplank_id_token")
+	sessionIDToken, err := s.gangplankUserSession.Session.Get(r, "gangplank_id_token")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return nil
 	}
-	sessionRefreshToken, err := gangplankUserSession.Session.Get(r, "gangplank_refresh_token")
+	sessionRefreshToken, err := s.gangplankUserSession.Session.Get(r, "gangplank_refresh_token")
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return nil
@@ -347,41 +334,41 @@ func generateInfo(w http.ResponseWriter, r *http.Request) *userInfo {
 
 	idToken, ok := sessionIDToken.Values["id_token"].(string)
 	if !ok {
-		gangplankUserSession.Cleanup(w, r, "gangplank")
-		gangplankUserSession.Cleanup(w, r, "gangplank_id_token")
-		gangplankUserSession.Cleanup(w, r, "gangplank_refresh_token")
-
+		s.cleanupAllSessions(w, r)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return nil
 	}
 
 	refreshToken, ok := sessionRefreshToken.Values["refresh_token"].(string)
 	if !ok {
-		gangplankUserSession.Cleanup(w, r, "gangplank")
-		gangplankUserSession.Cleanup(w, r, "gangplank_id_token")
-		gangplankUserSession.Cleanup(w, r, "gangplank_refresh_token")
-
+		s.cleanupAllSessions(w, r)
 		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return nil
 	}
 
-	jwtToken, err := oidc.ParseToken(idToken, cfg.ClientSecret)
+	jwtToken, err := oidc.ParseToken(idToken, s.cfg.ClientSecret)
 	if err != nil {
 		http.Error(w, "Could not parse JWT", http.StatusInternalServerError)
 		return nil
 	}
 
-	claims := jwtToken.Claims.(jwt.MapClaims)
-	username, ok := claims[cfg.UsernameClaim].(string)
+	claims, ok := jwtToken.Claims.(jwt.MapClaims)
+	if !ok {
+		http.Error(w, "Could not parse JWT claims", http.StatusInternalServerError)
+		return nil
+	}
+	username, ok := claims[s.cfg.UsernameClaim].(string)
 	if !ok {
 		http.Error(w, "Could not parse Username claim", http.StatusInternalServerError)
 		return nil
 	}
 
-	kubeCfgUser := strings.Join([]string{username, cfg.ClusterName}, "@")
+	kubeCfgUser := strings.Join([]string{username, s.cfg.ClusterName}, "@")
 
-	if cfg.EmailClaim != "" {
-		slog.Warn("Using the Email Claim config setting is deprecated. Gangplank uses `UsernameClaim@ClusterName`. This field will be removed in a future version.")
+	if s.cfg.EmailClaim != "" {
+		slog.Warn(
+			"Using the Email Claim config setting is deprecated. Gangplank uses `UsernameClaim@ClusterName`. This field will be removed in a future version.",
+		)
 	}
 
 	issuerURL, ok := claims["iss"].(string)
@@ -390,25 +377,52 @@ func generateInfo(w http.ResponseWriter, r *http.Request) *userInfo {
 		return nil
 	}
 
-	if cfg.ClientSecret == "" {
-		slog.Warn("Setting an empty Client Secret should only be done if you have no other option and is an inherent security risk.")
+	if s.cfg.ClientSecret == "" {
+		slog.Warn(
+			"Setting an empty Client Secret should only be done if you have no other option and is an inherent security risk.",
+		)
 	}
 
 	info := &userInfo{
-		ClusterName:  cfg.ClusterName,
+		ClusterName:  s.cfg.ClusterName,
 		Username:     username,
 		Claims:       claims,
 		KubeCfgUser:  kubeCfgUser,
 		IDToken:      idToken,
 		RefreshToken: refreshToken,
-		ClientID:     cfg.ClientID,
-		ClientSecret: cfg.ClientSecret,
+		ClientID:     s.cfg.ClientID,
+		ClientSecret: s.cfg.ClientSecret,
 		IssuerURL:    issuerURL,
-		APIServerURL: cfg.APIServerURL,
+		APIServerURL: s.cfg.APIServerURL,
 		ClusterCA:    string(caBytes),
 		IDPCAb64:     string(idpCAb64Bytes),
-		HTTPPath:     cfg.HTTPPath,
-		Namespace:    cfg.Namespace,
+		HTTPPath:     s.cfg.HTTPPath,
+		Namespace:    s.cfg.Namespace,
 	}
 	return info
+}
+
+func (s *server) readCAFiles() ([]byte, []byte) {
+	if s.cfg.RemoveCAFromKubeconfig {
+		return nil, nil
+	}
+
+	caBytes, err := os.ReadFile(s.cfg.ClusterCAPath)
+	if err != nil {
+		slog.Error("Failed to open CA file", "error", err)
+		return nil, nil
+	}
+
+	var idpCAb64Bytes []byte
+	if s.cfg.IDPCAPath != "" {
+		idpBytes, idpErr := os.ReadFile(s.cfg.IDPCAPath)
+		if idpErr != nil {
+			slog.Error("Failed to open IDP file", "error", idpErr)
+		} else {
+			idpCAb64Bytes = make([]byte, base64.StdEncoding.EncodedLen(len(idpBytes)))
+			base64.StdEncoding.Encode(idpCAb64Bytes, idpBytes)
+		}
+	}
+
+	return caBytes, idpCAb64Bytes
 }

--- a/cmd/gangplank/handlers_test.go
+++ b/cmd/gangplank/handlers_test.go
@@ -29,44 +29,52 @@ import (
 	"golang.org/x/oauth2"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api/v1"
 
-	"github.com/gorilla/sessions"
 	"sigs.k8s.io/yaml"
 
 	"github.com/sighupio/gangplank/internal/config"
 	"github.com/sighupio/gangplank/internal/session"
 )
 
-func testInit() {
-	var err error
-	gangplankUserSession, err = session.New("test", false)
-	if err != nil {
-		panic(err)
-	}
-	transportConfig = config.NewTransportConfig("")
+const (
+	testClientSecret = "qwertyuiopasdfghjklzxcvbnm123456"
+	testIDToken      = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU"
+)
 
-	oauth2Cfg = &oauth2.Config{
+func newTestServer(t *testing.T) *server {
+	t.Helper()
+
+	userSession, err := session.New("test", false)
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	oauth2Cfg := &oauth2.Config{
 		ClientID:     "cfg.ClientID",
-		ClientSecret: "qwertyuiopasdfghjklzxcvbnm123456",
+		ClientSecret: testClientSecret,
 		RedirectURL:  "cfg.RedirectURL",
 	}
 
-	o2token = &FakeToken{
-		OAuth2Cfg: oauth2Cfg,
+	return &server{
+		gangplankUserSession: userSession,
+		transportConfig:      config.NewTransportConfig(""),
+		oauth2Cfg:            oauth2Cfg,
+		o2token:              &FakeToken{OAuth2Cfg: oauth2Cfg},
 	}
 }
 
 func TestHomeHandler(t *testing.T) {
-	req, err := http.NewRequest("GET", "/", nil)
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cfg = &config.Config{
+	ts := newTestServer(t)
+	ts.cfg = &config.Config{
 		HTTPPath: "",
 	}
 
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(homeHandler)
+	handler := http.HandlerFunc(ts.homeHandler)
 
 	handler.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusOK {
@@ -91,25 +99,20 @@ func TestCallbackHandler(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var req *http.Request
-			var rsp *httptest.ResponseRecorder
-			var session *sessions.Session
-			var err error
-
-			cfg = &config.Config{
+			ts := newTestServer(t)
+			ts.cfg = &config.Config{
 				HTTPPath: "/foo",
 			}
 
-			// Init variables
-			rsp = NewRecorder()
-			testInit()
-			req, err = http.NewRequest("GET", "/callback", nil)
+			rsp := NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/callback", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Create request
-			if session, err = gangplankUserSession.Session.Get(req, "gangplank"); err != nil {
+			session, err := ts.gangplankUserSession.Session.Get(req, "gangplank")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
 
@@ -126,7 +129,7 @@ func TestCallbackHandler(t *testing.T) {
 			}
 			req.URL.RawQuery = q.Encode()
 
-			handler := http.HandlerFunc(callbackHandler)
+			handler := http.HandlerFunc(ts.callbackHandler)
 
 			// Call Handler
 			handler.ServeHTTP(rsp, req)
@@ -135,10 +138,8 @@ func TestCallbackHandler(t *testing.T) {
 			if status := rsp.Code; status != tc.expectedStatusCode {
 				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.expectedStatusCode)
 			}
-
 		})
 	}
-
 }
 func TestCommandLineHandler(t *testing.T) {
 	tests := map[string]struct {
@@ -151,7 +152,7 @@ func TestCommandLineHandler(t *testing.T) {
 		"default": {
 			params: map[string]string{
 				"state":         "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=",
-				"id_token":      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"id_token":      testIDToken,
 				"refresh_token": "bar",
 				"code":          "0cj0VQzNl36e4P2L&state=jdep4ov52FeUuzWLDDtSXaF4b5%2F%2FCUJ52xlE69ehnQ8%3D",
 			},
@@ -163,7 +164,7 @@ func TestCommandLineHandler(t *testing.T) {
 		"incorrect username claim": {
 			params: map[string]string{
 				"state":         "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=",
-				"id_token":      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"id_token":      testIDToken,
 				"refresh_token": "bar",
 				"code":          "0cj0VQzNl36e4P2L&state=jdep4ov52FeUuzWLDDtSXaF4b5%2F%2FCUJ52xlE69ehnQ8%3D",
 			},
@@ -174,7 +175,7 @@ func TestCommandLineHandler(t *testing.T) {
 		"no email claim": {
 			params: map[string]string{
 				"state":         "Uv38ByGCZU8WP18PmmIdcpVmx00QA3xNe7sEB9Hixkk=",
-				"id_token":      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"id_token":      testIDToken,
 				"refresh_token": "bar",
 				"code":          "0cj0VQzNl36e4P2L&state=jdep4ov52FeUuzWLDDtSXaF4b5%2F%2FCUJ52xlE69ehnQ8%3D",
 			},
@@ -186,37 +187,33 @@ func TestCommandLineHandler(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var req *http.Request
-			var rsp *httptest.ResponseRecorder
-			var session *sessions.Session
-			var sessionIDToken *sessions.Session
-			var sessionRefreshToken *sessions.Session
-			var err error
-
-			cfg = &config.Config{
+			ts := newTestServer(t)
+			ts.cfg = &config.Config{
 				HTTPPath:      "/foo",
 				EmailClaim:    tc.emailClaim,
 				UsernameClaim: tc.usernameClaim,
 				ClusterName:   "cluster1",
 				APIServerURL:  "https://kubernetes",
+				ClientSecret:  testClientSecret,
 			}
 
-			// Init variables
-			rsp = NewRecorder()
-			testInit()
-			req, err = http.NewRequest("GET", "/callback", nil)
+			rsp := NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/callback", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Create request
-			if session, err = gangplankUserSession.Session.Get(req, "gangplank"); err != nil {
+			session, err := ts.gangplankUserSession.Session.Get(req, "gangplank")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
-			if sessionIDToken, err = gangplankUserSession.Session.Get(req, "gangplank_id_token"); err != nil {
+			sessionIDToken, err := ts.gangplankUserSession.Session.Get(req, "gangplank_id_token")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
-			if sessionRefreshToken, err = gangplankUserSession.Session.Get(req, "gangplank_refresh_token"); err != nil {
+			sessionRefreshToken, err := ts.gangplankUserSession.Session.Get(req, "gangplank_refresh_token")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
 
@@ -241,7 +238,7 @@ func TestCommandLineHandler(t *testing.T) {
 			}
 			req.URL.RawQuery = q.Encode()
 
-			handler := http.HandlerFunc(commandlineHandler)
+			handler := http.HandlerFunc(ts.commandlineHandler)
 
 			// Call Handler
 			handler.ServeHTTP(rsp, req)
@@ -280,10 +277,10 @@ func TestKubeconfigHandler(t *testing.T) {
 				ClusterName:   "cluster1",
 				APIServerURL:  "https://kubernetes",
 				ClientID:      "someClientID",
-				ClientSecret:  "someClientSecret",
+				ClientSecret:  testClientSecret,
 			},
 			params: map[string]string{
-				"id_token":      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"id_token":      testIDToken,
 				"refresh_token": "bar",
 			},
 			expectedStatusCode:   http.StatusOK,
@@ -291,8 +288,8 @@ func TestKubeconfigHandler(t *testing.T) {
 			expectedAuthInfoName: "gangway@heptio.com@cluster1",
 			expectedAuthInfoAuthProviderConfig: map[string]string{
 				"client-id":                      "someClientID",
-				"client-secret":                  "someClientSecret",
-				"id-token":                       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"client-secret":                  testClientSecret,
+				"id-token":                       testIDToken,
 				"refresh-token":                  "bar",
 				"idp-issuer-url":                 "GangwayTest",
 				"idp-certificate-authority-data": "ZHVtbXkgY2x1c3RlciBJRFAgQ0E=",
@@ -305,10 +302,10 @@ func TestKubeconfigHandler(t *testing.T) {
 				ClusterName:   "cluster1",
 				APIServerURL:  "https://kubernetes",
 				ClientID:      "someClientID",
-				ClientSecret:  "someClientSecret",
+				ClientSecret:  testClientSecret,
 			},
 			params: map[string]string{
-				"id_token":      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"id_token":      testIDToken,
 				"refresh_token": "bar",
 				"filename":      "my-custom-cluster",
 			},
@@ -317,8 +314,8 @@ func TestKubeconfigHandler(t *testing.T) {
 			expectedAuthInfoName: "gangway@heptio.com@cluster1",
 			expectedAuthInfoAuthProviderConfig: map[string]string{
 				"client-id":                      "someClientID",
-				"client-secret":                  "someClientSecret",
-				"id-token":                       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+				"client-secret":                  testClientSecret,
+				"id-token":                       testIDToken,
 				"refresh-token":                  "bar",
 				"idp-issuer-url":                 "GangwayTest",
 				"idp-certificate-authority-data": "ZHVtbXkgY2x1c3RlciBJRFAgQ0E=",
@@ -329,16 +326,12 @@ func TestKubeconfigHandler(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			var req *http.Request
-			var rsp *httptest.ResponseRecorder
-			var session *sessions.Session
-			var sessionIDToken *sessions.Session
-			var sessionRefreshToken *sessions.Session
-			var err error
+			ts := newTestServer(t)
+			ts.cfg = &tc.cfg
 
 			// Create dummy cluster CA file
 			clusterCAData := "dummy cluster CA"
-			f, err := os.CreateTemp("", "gangplank-kubeconfig-handler-test")
+			f, err := os.CreateTemp(t.TempDir(), "gangplank-kubeconfig-handler-test")
 			if err != nil {
 				t.Fatalf("Error creating temp file: %v", err)
 			}
@@ -346,33 +339,32 @@ func TestKubeconfigHandler(t *testing.T) {
 
 			// Create dummy cluster IDP CA file
 			idpCAData := "dummy cluster IDP CA"
-			fIdp, err := os.CreateTemp("", "gangplank-kubeconfig-handler-test-idp")
+			fIdp, err := os.CreateTemp(t.TempDir(), "gangplank-kubeconfig-handler-test-idp")
 			if err != nil {
 				t.Fatalf("Error creating temp file: %v", err)
 			}
 			fmt.Fprint(fIdp, idpCAData)
 
-			// Set config global var
-			cfg = &tc.cfg
-			cfg.ClusterCAPath = f.Name()
-			cfg.IDPCAPath = fIdp.Name()
+			ts.cfg.ClusterCAPath = f.Name()
+			ts.cfg.IDPCAPath = fIdp.Name()
 
-			// Init variables
-			rsp = NewRecorder()
-			testInit()
-			req, err = http.NewRequest("GET", "/kubeconf", nil)
+			rsp := NewRecorder()
+			req, err := http.NewRequest(http.MethodGet, "/kubeconf", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Create request
-			if session, err = gangplankUserSession.Session.Get(req, "gangplank"); err != nil {
+			session, err := ts.gangplankUserSession.Session.Get(req, "gangplank")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
-			if sessionIDToken, err = gangplankUserSession.Session.Get(req, "gangplank_id_token"); err != nil {
+			sessionIDToken, err := ts.gangplankUserSession.Session.Get(req, "gangplank_id_token")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
-			if sessionRefreshToken, err = gangplankUserSession.Session.Get(req, "gangplank_refresh_token"); err != nil {
+			sessionRefreshToken, err := ts.gangplankUserSession.Session.Get(req, "gangplank_refresh_token")
+			if err != nil {
 				t.Fatalf("Error getting session: %v", err)
 			}
 
@@ -395,7 +387,7 @@ func TestKubeconfigHandler(t *testing.T) {
 			}
 			req.URL.RawQuery = q.Encode()
 
-			handler := http.HandlerFunc(kubeConfigHandler)
+			handler := http.HandlerFunc(ts.kubeConfigHandler)
 
 			// Call Handler
 			handler.ServeHTTP(rsp, req)
@@ -415,74 +407,94 @@ func TestKubeconfigHandler(t *testing.T) {
 				t.Errorf("Content-Type = %q; want %q", gotCT, "application/yaml")
 			}
 
-			// if response code is OK, validate the kubeconfig
-			if rsp.Code == 200 {
-				bodyBytes, err := io.ReadAll(rsp.Body)
-				if err != nil {
-					t.Fatalf("error reading body: %v", err)
-				}
-				kubeconfig := &clientcmdapi.Config{}
-				if err := yaml.Unmarshal(bodyBytes, kubeconfig); err != nil {
-					t.Fatalf("error unmarshaling response: %v", err)
-				}
-
-				// Validate cluster
-				if len(kubeconfig.Clusters) != 1 {
-					t.Fatalf("Found %d clusters in the generated kubeconfig, expected 1", len(kubeconfig.Clusters))
-				}
-				cluster := kubeconfig.Clusters[0]
-				if cluster.Name != cfg.ClusterName {
-					t.Errorf("Expected cluster name to be %q, but found %q", cfg.ClusterName, kubeconfig.Clusters[0].Name)
-				}
-				if cluster.Cluster.Server != cfg.APIServerURL {
-					t.Errorf("Expected cluster server to be %q, but found %q", cfg.APIServerURL, cluster.Cluster.Server)
-				}
-				if string(cluster.Cluster.CertificateAuthorityData) != clusterCAData {
-					t.Errorf("Expected cluster CA Data %q, but got %q", clusterCAData, string(cluster.Cluster.CertificateAuthorityData))
-				}
-
-				// Validate AuthInfo
-				if len(kubeconfig.AuthInfos) != 1 {
-					t.Fatalf("Found %d users in the generated kubeconfig, expected 1", len(kubeconfig.AuthInfos))
-				}
-				authInfo := kubeconfig.AuthInfos[0]
-				if authInfo.Name != tc.expectedAuthInfoName {
-					t.Errorf("Expected AuthInfo.Name %q, but got %q", tc.expectedAuthInfoName, authInfo.Name)
-				}
-
-				if authInfo.AuthInfo.AuthProvider.Name != "oidc" {
-					t.Errorf("expecetd authprovider to be oidc, got %s", authInfo.AuthInfo.AuthProvider.Name)
-				}
-				if !reflect.DeepEqual(authInfo.AuthInfo.AuthProvider.Config, tc.expectedAuthInfoAuthProviderConfig) {
-					t.Errorf("Expected %v, got %v", tc.expectedAuthInfoAuthProviderConfig, authInfo.AuthInfo.AuthProvider.Config)
-				}
-
-				// Validate context
-				if len(kubeconfig.Contexts) != 1 {
-					t.Fatalf("Found %d contexts in the generated kubeconfig, expected 1", len(kubeconfig.Contexts))
-				}
-				context := kubeconfig.Contexts[0]
-				if context.Name != cfg.ClusterName {
-					t.Errorf("Expected context name to be %q, but found %q", cfg.ClusterName, context.Name)
-				}
-				if context.Context.Cluster != cluster.Name {
-					t.Errorf("Cluster name %q in context does not match cluster name %q", context.Context.Cluster, cluster.Name)
-				}
-				if context.Context.AuthInfo != authInfo.Name {
-					t.Errorf("AuthInfo name %q in context does not match user name %q", context.Context.AuthInfo, authInfo.Name)
-				}
-				if kubeconfig.CurrentContext != context.Name {
-					t.Errorf("Current context %q does not match context name %q", kubeconfig.CurrentContext, context.Name)
-				}
+			if rsp.Code != 200 {
+				t.Fatalf("expected status 200, got %d", rsp.Code)
 			}
+
+			validateKubeconfig(
+				t, rsp, ts.cfg, clusterCAData,
+				tc.expectedAuthInfoName, tc.expectedAuthInfoAuthProviderConfig,
+			)
 		})
 	}
 }
 
-func TestUnauthedCommandlineHandlerRedirect(t *testing.T) {
-	testInit()
+func validateKubeconfig(
+	t *testing.T,
+	rsp *httptest.ResponseRecorder,
+	cfg *config.Config,
+	clusterCAData string,
+	expectedAuthInfoName string,
+	expectedAuthProviderConfig map[string]string,
+) {
+	t.Helper()
 
-	req, err := http.NewRequest("GET", "/commandline", nil)
+	bodyBytes, readErr := io.ReadAll(rsp.Body)
+	if readErr != nil {
+		t.Fatalf("error reading body: %v", readErr)
+	}
+	kubeconfig := &clientcmdapi.Config{}
+	if unmarshalErr := yaml.Unmarshal(bodyBytes, kubeconfig); unmarshalErr != nil {
+		t.Fatalf("error unmarshaling response: %v", unmarshalErr)
+	}
+
+	// Validate cluster
+	if len(kubeconfig.Clusters) != 1 {
+		t.Fatalf("Found %d clusters in the generated kubeconfig, expected 1", len(kubeconfig.Clusters))
+	}
+	cluster := kubeconfig.Clusters[0]
+	if cluster.Name != cfg.ClusterName {
+		t.Errorf("Expected cluster name to be %q, but found %q", cfg.ClusterName, cluster.Name)
+	}
+	if cluster.Cluster.Server != cfg.APIServerURL {
+		t.Errorf("Expected cluster server to be %q, but found %q", cfg.APIServerURL, cluster.Cluster.Server)
+	}
+	if string(cluster.Cluster.CertificateAuthorityData) != clusterCAData {
+		t.Errorf(
+			"Expected cluster CA Data %q, but got %q",
+			clusterCAData, string(cluster.Cluster.CertificateAuthorityData),
+		)
+	}
+
+	// Validate AuthInfo
+	if len(kubeconfig.AuthInfos) != 1 {
+		t.Fatalf("Found %d users in the generated kubeconfig, expected 1", len(kubeconfig.AuthInfos))
+	}
+	authInfo := kubeconfig.AuthInfos[0]
+	if authInfo.Name != expectedAuthInfoName {
+		t.Errorf("Expected AuthInfo.Name %q, but got %q", expectedAuthInfoName, authInfo.Name)
+	}
+	if authInfo.AuthInfo.AuthProvider.Name != "oidc" {
+		t.Errorf("expected authprovider to be oidc, got %s", authInfo.AuthInfo.AuthProvider.Name)
+	}
+	if !reflect.DeepEqual(authInfo.AuthInfo.AuthProvider.Config, expectedAuthProviderConfig) {
+		t.Errorf("Expected %v, got %v", expectedAuthProviderConfig, authInfo.AuthInfo.AuthProvider.Config)
+	}
+
+	// Validate context
+	if len(kubeconfig.Contexts) != 1 {
+		t.Fatalf("Found %d contexts in the generated kubeconfig, expected 1", len(kubeconfig.Contexts))
+	}
+	ctx := kubeconfig.Contexts[0]
+	if ctx.Name != cfg.ClusterName {
+		t.Errorf("Expected context name to be %q, but found %q", cfg.ClusterName, ctx.Name)
+	}
+	if ctx.Context.Cluster != cluster.Name {
+		t.Errorf("Cluster name %q in context does not match cluster name %q", ctx.Context.Cluster, cluster.Name)
+	}
+	if ctx.Context.AuthInfo != authInfo.Name {
+		t.Errorf("AuthInfo name %q in context does not match user name %q", ctx.Context.AuthInfo, authInfo.Name)
+	}
+	if kubeconfig.CurrentContext != ctx.Name {
+		t.Errorf("Current context %q does not match context name %q", kubeconfig.CurrentContext, ctx.Name)
+	}
+}
+
+func TestUnauthedCommandlineHandlerRedirect(t *testing.T) {
+	ts := newTestServer(t)
+	ts.cfg = &config.Config{}
+
+	req, err := http.NewRequest(http.MethodGet, "/commandline", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,7 +502,7 @@ func TestUnauthedCommandlineHandlerRedirect(t *testing.T) {
 	session.New("test", false)
 
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(commandlineHandler)
+	handler := http.HandlerFunc(ts.commandlineHandler)
 
 	handler.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusTemporaryRedirect {
@@ -507,14 +519,59 @@ func NewRecorder() *httptest.ResponseRecorder {
 	}
 }
 
+func TestSanitizeFilename(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		"clean": {
+			input:    "kubeconfig",
+			expected: "kubeconfig",
+		},
+		"with quotes": {
+			input:    `file"name`,
+			expected: "file_name",
+		},
+		"with backslash": {
+			input:    `file\name`,
+			expected: "file_name",
+		},
+		"with slash": {
+			input:    "file/name",
+			expected: "file_name",
+		},
+		"with newlines": {
+			input:    "file\r\nname",
+			expected: "file__name",
+		},
+		"header injection attempt": {
+			input:    "file\r\nX-Injected: true",
+			expected: "file__X-Injected: true",
+		},
+		"empty": {
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := sanitizeFilename(tc.input)
+			if got != tc.expected {
+				t.Errorf("sanitizeFilename(%q) = %q, want %q", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
 type FakeToken struct {
 	OAuth2Cfg *oauth2.Config
 }
 
-// Exchange takes an oauth2 auth token and exchanges for an id_token
-func (f *FakeToken) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
+// Exchange takes an oauth2 auth token and exchanges for an id_token.
+func (f *FakeToken) Exchange(_ context.Context, _ string) (*oauth2.Token, error) {
 	return &oauth2.Token{
-		AccessToken:  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
+		AccessToken:  testIDToken,
 		RefreshToken: "4567",
 	}, nil
 }

--- a/cmd/gangplank/main.go
+++ b/cmd/gangplank/main.go
@@ -26,20 +26,25 @@ import (
 	"time"
 
 	"github.com/justinas/alice"
+	"golang.org/x/oauth2"
+
 	"github.com/sighupio/gangplank/internal/config"
 	"github.com/sighupio/gangplank/internal/oidc"
 	"github.com/sighupio/gangplank/internal/session"
 	"github.com/sighupio/gangplank/static"
-	"golang.org/x/oauth2"
 )
 
-var cfg *config.Config
-var oauth2Cfg *oauth2.Config
-var o2token oidc.OAuth2Token
-var gangplankUserSession *session.Session
-var transportConfig *config.TransportConfig
+const httpServerTimeout = 10 * time.Second
 
-// wrapper function for http logging
+type server struct {
+	cfg                  *config.Config
+	oauth2Cfg            *oauth2.Config
+	o2token              oidc.OAuth2Token
+	gangplankUserSession *session.Session
+	transportConfig      *config.TransportConfig
+}
+
+// wrapper function for http logging.
 func httpLogger(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer slog.Debug("HTTP log", "method", r.Method, "url", r.URL, "remote-addr", r.RemoteAddr)
@@ -47,29 +52,13 @@ func httpLogger(fn http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-func main() {
-	cfgFile := flag.String("config", "", "The config file to use.")
-	logLevel := flag.String("log-level", "info", "The log level to use. (debug, info, warn, error)")
-	flag.Parse()
-
-	var logLevelVar = new(slog.LevelVar)
-
-	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevelVar})
-	slog.SetDefault(slog.New(h))
-
-	if err := logLevelVar.UnmarshalText([]byte(*logLevel)); err != nil {
-		slog.Error("Could not parse log level", "error", err)
-		os.Exit(1)
-	}
-
-	var err error
-	cfg, err = config.NewConfig(*cfgFile)
+func newServer(cfgFile string) (*server, error) {
+	cfg, err := config.NewConfig(cfgFile)
 	if err != nil {
-		slog.Error("Could not parse config file", "error", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("could not parse config file: %w", err)
 	}
 
-	oauth2Cfg = &oauth2.Config{
+	oauth2Cfg := &oauth2.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,
 		RedirectURL:  cfg.RedirectURL,
@@ -80,38 +69,65 @@ func main() {
 		},
 	}
 
-	o2token = &oidc.Token{
-		OAuth2Cfg: oauth2Cfg,
+	userSession, err := session.New(cfg.SessionSecurityKey, cfg.ServeTLS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
-	transportConfig = config.NewTransportConfig(cfg.TrustedCAPath)
-	gangplankUserSession, err = session.New(cfg.SessionSecurityKey, cfg.ServeTLS)
-	if err != nil {
-		slog.Error("Failed to create session", "error", err)
+	return &server{
+		cfg:                  cfg,
+		oauth2Cfg:            oauth2Cfg,
+		o2token:              &oidc.Token{OAuth2Cfg: oauth2Cfg},
+		transportConfig:      config.NewTransportConfig(cfg.TrustedCAPath),
+		gangplankUserSession: userSession,
+	}, nil
+}
+
+func main() {
+	cfgFile := flag.String("config", "", "The config file to use.")
+	logLevel := flag.String("log-level", "info", "The log level to use. (debug, info, warn, error)")
+	flag.Parse()
+
+	logLevelVar := new(slog.LevelVar)
+
+	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevelVar})
+	slog.SetDefault(slog.New(h))
+
+	if err := logLevelVar.UnmarshalText([]byte(*logLevel)); err != nil {
+		slog.Error("Could not parse log level", "error", err)
 		os.Exit(1)
 	}
 
-	loginRequiredHandlers := alice.New(loginRequired)
+	s, err := newServer(*cfgFile)
+	if err != nil {
+		slog.Error("Could not initialize server", "error", err)
+		os.Exit(1)
+	}
 
-	http.HandleFunc(cfg.GetRootPathPrefix(), httpLogger(homeHandler))
-	http.HandleFunc(fmt.Sprintf("%s/static/", cfg.HTTPPath), httpLogger(http.StripPrefix(fmt.Sprintf("%s/static/", cfg.HTTPPath), http.FileServerFS(static.FS)).ServeHTTP))
-	http.HandleFunc(fmt.Sprintf("%s/login", cfg.HTTPPath), httpLogger(loginHandler))
-	http.HandleFunc(fmt.Sprintf("%s/callback", cfg.HTTPPath), httpLogger(callbackHandler))
+	loginRequiredHandlers := alice.New(s.loginRequired)
+
+	http.HandleFunc(s.cfg.GetRootPathPrefix(), httpLogger(s.homeHandler))
+	http.HandleFunc(
+		fmt.Sprintf("%s/static/", s.cfg.HTTPPath),
+		httpLogger(http.StripPrefix(fmt.Sprintf("%s/static/", s.cfg.HTTPPath), http.FileServerFS(static.FS)).ServeHTTP),
+	)
+	http.HandleFunc(fmt.Sprintf("%s/login", s.cfg.HTTPPath), httpLogger(s.loginHandler))
+	http.HandleFunc(fmt.Sprintf("%s/callback", s.cfg.HTTPPath), httpLogger(s.callbackHandler))
 
 	// middleware'd routes
-	http.Handle(fmt.Sprintf("%s/logout", cfg.HTTPPath), loginRequiredHandlers.ThenFunc(logoutHandler))
-	http.Handle(fmt.Sprintf("%s/commandline", cfg.HTTPPath), loginRequiredHandlers.ThenFunc(commandlineHandler))
-	http.Handle(fmt.Sprintf("%s/kubeconf", cfg.HTTPPath), loginRequiredHandlers.ThenFunc(kubeConfigHandler))
+	http.Handle(fmt.Sprintf("%s/logout", s.cfg.HTTPPath), loginRequiredHandlers.ThenFunc(s.logoutHandler))
+	http.Handle(fmt.Sprintf("%s/commandline", s.cfg.HTTPPath), loginRequiredHandlers.ThenFunc(s.commandlineHandler))
+	http.Handle(fmt.Sprintf("%s/kubeconf", s.cfg.HTTPPath), loginRequiredHandlers.ThenFunc(s.kubeConfigHandler))
 
-	bindAddr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	bindAddr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 	// create http server with timeouts
 	httpServer := &http.Server{
 		Addr:         bindAddr,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  httpServerTimeout,
+		WriteTimeout: httpServerTimeout,
 	}
 
-	if cfg.ServeTLS {
+	if s.cfg.ServeTLS {
 		// update http server with TLS config
 		httpServer.TLSConfig = &tls.Config{
 			CipherSuites: []uint16{
@@ -121,8 +137,6 @@ func main() {
 				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
 			},
 			MinVersion: tls.VersionTLS12,
 		}
@@ -134,25 +148,31 @@ func main() {
 
 		// exit with FATAL logging why we could not start
 		// example: FATA[0000] listen tcp 0.0.0.0:8080: bind: address already in use
-		if cfg.ServeTLS {
-			if err := httpServer.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile); err != nil {
-				slog.Error("Could not start HTTPS server", "error", err)
+		if s.cfg.ServeTLS {
+			if serveErr := httpServer.ListenAndServeTLS(s.cfg.CertFile, s.cfg.KeyFile); serveErr != nil {
+				slog.Error("Could not start HTTPS server", "error", serveErr)
 				os.Exit(1)
 			}
 		} else {
-			if err := httpServer.ListenAndServe(); err != nil {
-				slog.Error("Could not start HTTP server", "error", err)
+			if serveErr := httpServer.ListenAndServe(); serveErr != nil {
+				slog.Error("Could not start HTTP server", "error", serveErr)
 				os.Exit(1)
 			}
 		}
 	}()
 
-	// create channel listening for signals so we can have graceful shutdowns
+	gracefulShutdown(httpServer)
+}
+
+func gracefulShutdown(srv *http.Server) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	<-signalChan
 
 	slog.Info("Shutdown signal received, exiting")
-	// close the HTTP server
-	httpServer.Shutdown(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), httpServerTimeout)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Error("Error shutting down HTTP server", "error", err)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,44 +23,45 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// Config the configuration field for gangplank
+const defaultPort = 8080
+
+// Config the configuration field for gangplank.
 type Config struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
 
-	ClusterName            string   `yaml:"clusterName" envconfig:"cluster_name"`
-	AuthorizeURL           string   `yaml:"authorizeURL" envconfig:"authorize_url"`
-	TokenURL               string   `yaml:"tokenURL" envconfig:"token_url"`
-	ClientID               string   `yaml:"clientID" envconfig:"client_id"`
-	ClientSecret           string   `yaml:"clientSecret" envconfig:"client_secret"`
+	ClusterName            string   `yaml:"clusterName"            envconfig:"cluster_name"`
+	AuthorizeURL           string   `yaml:"authorizeURL"           envconfig:"authorize_url"`
+	TokenURL               string   `yaml:"tokenURL"               envconfig:"token_url"`
+	ClientID               string   `yaml:"clientID"               envconfig:"client_id"`
+	ClientSecret           string   `yaml:"clientSecret"           envconfig:"client_secret"`
 	AllowEmptyClientSecret bool     `yaml:"allowEmptyClientSecret" envconfig:"allow_empty_client_secret"`
-	Audience               string   `yaml:"audience" envconfig:"audience"`
-	RedirectURL            string   `yaml:"redirectURL" envconfig:"redirect_url"`
-	Scopes                 []string `yaml:"scopes" envconfig:"scopes"`
-	UsernameClaim          string   `yaml:"usernameClaim" envconfig:"username_claim"`
-	EmailClaim             string   `yaml:"emailClaim" envconfig:"email_claim"`
-	ServeTLS               bool     `yaml:"serveTLS" envconfig:"serve_tls"`
-	CertFile               string   `yaml:"certFile" envconfig:"cert_file"`
-	KeyFile                string   `yaml:"keyFile" envconfig:"key_file"`
-	APIServerURL           string   `yaml:"apiServerURL" envconfig:"apiserver_url"`
-	ClusterCAPath          string   `yaml:"clusterCAPath" envconfig:"cluster_ca_path"`
-	IDPCAPath              string   `yaml:"idpCAPath" envconfig:"idp_ca_path"`
-	TrustedCAPath          string   `yaml:"trustedCAPath" envconfig:"trusted_ca_path"`
-	HTTPPath               string   `yaml:"httpPath" envconfig:"http_path"`
+	Audience               string   `yaml:"audience"               envconfig:"audience"`
+	RedirectURL            string   `yaml:"redirectURL"            envconfig:"redirect_url"`
+	Scopes                 []string `yaml:"scopes"                 envconfig:"scopes"`
+	UsernameClaim          string   `yaml:"usernameClaim"          envconfig:"username_claim"`
+	EmailClaim             string   `yaml:"emailClaim"             envconfig:"email_claim"`
+	ServeTLS               bool     `yaml:"serveTLS"               envconfig:"serve_tls"`
+	CertFile               string   `yaml:"certFile"               envconfig:"cert_file"`
+	KeyFile                string   `yaml:"keyFile"                envconfig:"key_file"`
+	APIServerURL           string   `yaml:"apiServerURL"           envconfig:"apiserver_url"`
+	ClusterCAPath          string   `yaml:"clusterCAPath"          envconfig:"cluster_ca_path"`
+	IDPCAPath              string   `yaml:"idpCAPath"              envconfig:"idp_ca_path"`
+	TrustedCAPath          string   `yaml:"trustedCAPath"          envconfig:"trusted_ca_path"`
+	HTTPPath               string   `yaml:"httpPath"               envconfig:"http_path"`
 
-	SessionSecurityKey     string `yaml:"sessionSecurityKey" envconfig:"SESSION_SECURITY_KEY"`
+	SessionSecurityKey     string `yaml:"sessionSecurityKey"     envconfig:"SESSION_SECURITY_KEY"`
 	CustomHTMLTemplatesDir string `yaml:"customHTMLTemplatesDir" envconfig:"custom_http_templates_dir"`
 
 	RemoveCAFromKubeconfig bool   `yaml:"removeCAFromKubeconfig" envconfig:"remove_ca_from_kubeconfig"`
-	Namespace              string `yaml:"namespace" envconfig:"namespace"`
+	Namespace              string `yaml:"namespace"              envconfig:"namespace"`
 }
 
-// NewConfig returns a Config struct from serialized config file
+// NewConfig returns a Config struct from serialized config file.
 func NewConfig(configFile string) (*Config, error) {
-
 	cfg := &Config{
 		Host:                   "0.0.0.0",
-		Port:                   8080,
+		Port:                   defaultPort,
 		AllowEmptyClientSecret: false,
 		Scopes:                 []string{"openid", "profile", "email", "offline_access"},
 		UsernameClaim:          "nickname",
@@ -102,7 +103,7 @@ func NewConfig(configFile string) (*Config, error) {
 	return cfg, nil
 }
 
-// Validate verifies all properties of config struct are intialized
+// Validate verifies all properties of the config struct are initialized.
 func (cfg *Config) Validate() error {
 	checks := []struct {
 		bad    bool
@@ -125,7 +126,7 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
-// GetRootPathPrefix returns '/' if no prefix is specified, otherwise returns the configured path
+// GetRootPathPrefix returns '/' if no prefix is specified, otherwise returns the configured path.
 func (cfg *Config) GetRootPathPrefix() string {
 	if len(cfg.HTTPPath) == 0 {
 		return "/"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,7 +57,11 @@ func TestEnvionmentOverrides(t *testing.T) {
 	}
 
 	if cfg.RemoveCAFromKubeconfig != true {
-		t.Errorf("Failed to set RemoveCAFromKubeconfig via environment variable. Expected %t but got %t", true, cfg.RemoveCAFromKubeconfig)
+		t.Errorf(
+			"Failed to set RemoveCAFromKubeconfig via environment variable. Expected %t but got %t",
+			true,
+			cfg.RemoveCAFromKubeconfig,
+		)
 	}
 
 	if cfg.Namespace != "default" {

--- a/internal/config/transport.go
+++ b/internal/config/transport.go
@@ -23,12 +23,20 @@ import (
 	"time"
 )
 
-// TransportConfig describes a configured httpClient
+const (
+	dialTimeout         = 30 * time.Second
+	dialKeepAlive       = 30 * time.Second
+	maxIdleConns        = 100
+	idleConnTimeout     = 90 * time.Second
+	tlsHandshakeTimeout = 10 * time.Second
+)
+
+// TransportConfig describes a configured httpClient.
 type TransportConfig struct {
 	HTTPClient *http.Client
 }
 
-// NewTransportConfig returns a TransportConfig with configured httpClient
+// NewTransportConfig returns a TransportConfig with a configured httpClient.
 func NewTransportConfig(trustedCAPath string) *TransportConfig {
 	rootCAs, _ := x509.SystemCertPool()
 	if rootCAs == nil {
@@ -53,12 +61,12 @@ func NewTransportConfig(trustedCAPath string) *TransportConfig {
 	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
+			Timeout:   dialTimeout,
+			KeepAlive: dialKeepAlive,
 		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
+		MaxIdleConns:          maxIdleConns,
+		IdleConnTimeout:       idleConnTimeout,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
 			RootCAs:    rootCAs,

--- a/internal/oidc/token.go
+++ b/internal/oidc/token.go
@@ -15,7 +15,6 @@ package oidc
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
@@ -31,16 +30,14 @@ type Token struct {
 	OAuth2Cfg *oauth2.Config
 }
 
-// ParseToken returns a jwt token from an idToken, returns an error if it cannot parse.
-func ParseToken(idToken, clientSecret string) (*jwt.Token, error) {
-	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-		return []byte(clientSecret), nil
-	})
+// ParseToken returns a jwt token from an idToken by parsing it without signature verification.
+// Signature verification is handled by the OIDC provider, this function only extracts claims.
+func ParseToken(idToken, _ string) (*jwt.Token, error) {
+	parser := jwt.NewParser()
+
+	token, _, err := parser.ParseUnverified(idToken, jwt.MapClaims{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse token: %w", err)
+		return nil, err
 	}
 
 	return token, nil

--- a/internal/oidc/token.go
+++ b/internal/oidc/token.go
@@ -21,29 +21,32 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// OAuth2Token is an interface which is used when exchanging an id_token for an access token
+// OAuth2Token is an interface used when exchanging an id_token for an access token.
 type OAuth2Token interface {
 	Exchange(ctx context.Context, code string) (*oauth2.Token, error)
 }
 
-// Token is an implementation of OAuth2Token Interface
+// Token is an implementation of OAuth2Token Interface.
 type Token struct {
 	OAuth2Cfg *oauth2.Config
 }
 
-// ParseToken returns a jwt token from an idToken, returns error if it cannot parse
+// ParseToken returns a jwt token from an idToken, returns an error if it cannot parse.
 func ParseToken(idToken, clientSecret string) (*jwt.Token, error) {
-	token, _ := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
+	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return []byte(clientSecret), nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token: %w", err)
+	}
 
 	return token, nil
 }
 
-// Exchange takes an oauth2 auth token and exchanges for an id_token
+// Exchange takes an oauth2 auth token and exchanges for an id_token.
 func (t *Token) Exchange(ctx context.Context, code string) (*oauth2.Token, error) {
 	return t.OAuth2Cfg.Exchange(ctx, code)
 }

--- a/internal/oidc/token_test.go
+++ b/internal/oidc/token_test.go
@@ -44,7 +44,7 @@ func TestParseToken(t *testing.T) {
 			want: &jwt.Token{
 				Raw:    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
 				Method: jwt.SigningMethodHS256,
-				Header: map[string]interface{}{
+				Header: map[string]any{
 					"typ": "JWT",
 					"alg": "HS256",
 				},
@@ -63,31 +63,15 @@ func TestParseToken(t *testing.T) {
 				Valid:     true,
 			},
 		},
-		"rsa": {
+		"rsa is rejected": {
 			idToken:      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE",
 			clientSecret: "",
-			expectError:  false,
-			want: &jwt.Token{
-				Raw:    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE",
-				Method: jwt.SigningMethodRS256,
-				Header: map[string]interface{}{
-					"alg": "RS256",
-					"typ": "JWT",
-				},
-				Claims: jwt.MapClaims{
-					"sub":   "1234567890",
-					"name":  "John Doe",
-					"admin": true,
-				},
-				Signature: base64Decode("EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE"),
-				Valid:     false,
-			},
+			expectError:  true,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			got, err := ParseToken(tc.idToken, tc.clientSecret)
 
 			// If we expect an error, check that it's thrown
@@ -95,32 +79,42 @@ func TestParseToken(t *testing.T) {
 				if err == nil {
 					t.Fatalf("Error was returned but not expected: %v", err)
 				}
-			} else {
-				// We don't expect an error, check the result
-				if got.Valid != tc.want.Valid {
-					t.Fatalf("Valid: want: %v, got: %v", tc.want, got)
-				}
-				if !bytes.Equal(got.Signature, tc.want.Signature) {
-					t.Fatalf("Signature: want: %v, got: %v", tc.want.Signature, got.Signature)
-				}
-				if got.Raw != tc.want.Raw {
-					t.Fatalf("Raw: want: %v, got: %v", tc.want, got)
-				}
-				if got.Method != tc.want.Method {
-					t.Fatalf("Method: want: %v, got: %v", tc.want, got)
-				}
-				if !eq(got.Header, tc.want.Header) {
-					t.Fatalf("Header: want: %v, got: %v", tc.want, got)
-				}
-				if !eq(got.Claims.(jwt.MapClaims), tc.want.Claims.(jwt.MapClaims)) {
-					t.Fatalf("Header: want: %v, got: %v", tc.want, got)
-				}
+				return
 			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			validateToken(t, got, tc.want)
 		})
 	}
 }
 
-func eq(a, b map[string]interface{}) bool {
+func validateToken(t *testing.T, got, want *jwt.Token) {
+	t.Helper()
+
+	if got.Valid != want.Valid {
+		t.Fatalf("Valid: want: %v, got: %v", want, got)
+	}
+	if !bytes.Equal(got.Signature, want.Signature) {
+		t.Fatalf("Signature: want: %v, got: %v", want.Signature, got.Signature)
+	}
+	if got.Raw != want.Raw {
+		t.Fatalf("Raw: want: %v, got: %v", want, got)
+	}
+	if got.Method != want.Method {
+		t.Fatalf("Method: want: %v, got: %v", want, got)
+	}
+	if !eq(got.Header, want.Header) {
+		t.Fatalf("Header: want: %v, got: %v", want, got)
+	}
+	if !eq(got.Claims.(jwt.MapClaims), want.Claims.(jwt.MapClaims)) {
+		t.Fatalf("Header: want: %v, got: %v", want, got)
+	}
+}
+
+func eq(a, b map[string]any) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/internal/oidc/token_test.go
+++ b/internal/oidc/token_test.go
@@ -37,7 +37,7 @@ func TestParseToken(t *testing.T) {
 		want         *jwt.Token
 		expectError  bool
 	}{
-		"default": {
+		"hs256 token": {
 			idToken:      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJHYW5nd2F5VGVzdCIsImlhdCI6MTU0MDA0NjM0NywiZXhwIjoxODg3MjAxNTQ3LCJhdWQiOiJnYW5nd2F5LmhlcHRpby5jb20iLCJzdWIiOiJnYW5nd2F5QGhlcHRpby5jb20iLCJHaXZlbk5hbWUiOiJHYW5nIiwiU3VybmFtZSI6IldheSIsIkVtYWlsIjoiZ2FuZ3dheUBoZXB0aW8uY29tIiwiR3JvdXBzIjoiZGV2LGFkbWluIn0.zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU",
 			clientSecret: "qwertyuiopasdfghjklzxcvbnm123456",
 			expectError:  false,
@@ -60,13 +60,30 @@ func TestParseToken(t *testing.T) {
 					"Surname":   "Way",
 				},
 				Signature: base64Decode("zNG4Dnxr76J0p4phfsAUYWunioct0krkMiunMynlQsU"),
-				Valid:     true,
+				Valid:     false,
 			},
 		},
-		"rsa is rejected": {
+		"rsa token": {
 			idToken:      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE",
 			clientSecret: "",
-			expectError:  true,
+			expectError:  false,
+			want: &jwt.Token{
+				Raw:    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE",
+				Method: jwt.SigningMethodRS256,
+				Header: map[string]any{
+					"typ": "JWT",
+					"alg": "RS256",
+				},
+				Claims: jwt.MapClaims{
+					"sub":   "1234567890",
+					"name":  "John Doe",
+					"admin": true,
+				},
+				Signature: base64Decode(
+					"EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE",
+				),
+				Valid: false,
+			},
 		},
 	}
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -20,27 +20,36 @@ import (
 	"net/http"
 )
 
-const salt = "MkmfuPNHnZBBivy0L0aW"
+const (
+	salt             = "MkmfuPNHnZBBivy0L0aW"
+	pbkdf2Iterations = 4096
+	pbkdf2KeyLength  = 96
+)
 
-// Session defines a Gangplank session
+// Session defines a Gangplank session.
 type Session struct {
 	Session *CustomCookieStore
 }
 
-// New inits a Session with CookieStore
+// New inits a Session with CookieStore.
 func New(sessionSecurityKey string, secureCookies bool) (*Session, error) {
 	signingKey, encryptionKey, err := generateSessionKeys(sessionSecurityKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate session keys: %w", err)
 	}
 
+	store, err := NewCustomCookieStore(secureCookies, signingKey, encryptionKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cookie store: %w", err)
+	}
+
 	return &Session{
-		Session: NewCustomCookieStore(secureCookies, signingKey, encryptionKey),
+		Session: store,
 	}, nil
 }
 
-// generateSessionKeys creates a signed encryption key for the cookie store
-func generateSessionKeys(sessionSecurityKey string) (signingKey []byte, encryptionKey []byte, err error) {
+// generateSessionKeys creates a signed encryption key for the cookie store.
+func generateSessionKeys(sessionSecurityKey string) ([]byte, []byte, error) {
 	// Take the configured security key and generate 96 bytes of data. This is
 	// used as the signing and encryption keys for the cookie store.  For details
 	// on the PBKDF2 function: https://en.wikipedia.org/wiki/PBKDF2
@@ -48,7 +57,7 @@ func generateSessionKeys(sessionSecurityKey string) (signingKey []byte, encrypti
 		sha256.New,
 		sessionSecurityKey,
 		[]byte(salt),
-		4096, 96)
+		pbkdf2Iterations, pbkdf2KeyLength)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -56,13 +65,25 @@ func generateSessionKeys(sessionSecurityKey string) (signingKey []byte, encrypti
 	return derivedKey[:64], derivedKey[64:], nil
 }
 
-// Cleanup removes the current session from the store
-func (s *Session) Cleanup(w http.ResponseWriter, r *http.Request, name string) {
+// Cleanup removes a single session from the store.
+func (s *Session) Cleanup(w http.ResponseWriter, r *http.Request, name string) error {
 	session, err := s.Session.Get(r, name)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return fmt.Errorf("failed to get session %q: %w", name, err)
 	}
 	session.Options.MaxAge = -1
-	session.Save(r, w)
+	if saveErr := session.Save(r, w); saveErr != nil {
+		return fmt.Errorf("failed to save session %q: %w", name, saveErr)
+	}
+	return nil
+}
+
+// CleanupAll removes multiple sessions from the store.
+func (s *Session) CleanupAll(w http.ResponseWriter, r *http.Request, names ...string) error {
+	for _, name := range names {
+		if err := s.Cleanup(w, r, name); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -42,7 +42,6 @@ func TestInitSessionStore(t *testing.T) {
 		t.Errorf("Session Store is nil. Did not get initialized")
 		return
 	}
-
 }
 
 func TestCleanupSession(t *testing.T) {
@@ -55,7 +54,6 @@ func TestCleanupSession(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		session, _ = s.Session.Get(r, "gangplank")
 		s.Cleanup(w, r, "gangplank")
-
 	}))
 	defer ts.Close()
 	_, err = http.Get(ts.URL)

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -62,8 +62,7 @@ func (s *CustomCookieStore) Get(r *http.Request, name string) (*sessions.Session
 // The original cookie is split/joined in its encoded form.
 func (s *CustomCookieStore) New(r *http.Request, name string) (*sessions.Session, error) {
 	session := sessions.NewSession(s, name)
-	opts := *s.Options
-	session.Options = &opts
+	session.Options = new(*s.Options)
 	session.IsNew = true
 	cookie := joinSectionCookies(r, name)
 	var err error

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -16,43 +16,50 @@ package session
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 )
 
 // The CustomCookieStore automatically splits cookies with length greater than maxCookieLength into multiple smaller cookies.
-// The motivation is the browsers' 4KB limit on cookies, which for instance causes problems for large id_tokens in azure.
+// The motivation is the browsers' 4KB limit on cookies, which, for instance, causes problems for large id_tokens in azure.
 
 const (
 	// Cookies are limited to 4kb including the length of the cookie name,
-	// the cookie name can be up to 256 bytes
+	// the cookie name can be up to 256 bytes.
 	maxCookieLength = 3840
+	// maxSecureCookieLength is an arbitrary (20x4kb) high value since we split cookies
+	// and are no longer limited by a single cookie size.
+	maxSecureCookieLength = 81920
 )
 
 type CustomCookieStore struct {
 	*sessions.CookieStore
 }
 
-// NewCustomCookieStore Set secureCookie maxLength to an arbitrary (20x4kb) high value since we are no longer limited
-func NewCustomCookieStore(secureCookies bool, keyPairs ...[]byte) *CustomCookieStore {
+// NewCustomCookieStore Set secureCookie maxLength to an arbitrary (20x4kb) high value since we are no longer limited.
+func NewCustomCookieStore(secureCookies bool, keyPairs ...[]byte) (*CustomCookieStore, error) {
 	cookieStore := sessions.NewCookieStore(keyPairs...)
 	cookieStore.Options.Secure = secureCookies
 	cookieStore.Options.SameSite = http.SameSiteLaxMode
 	for _, codec := range cookieStore.Codecs {
-		cookie := codec.(*securecookie.SecureCookie)
-		cookie.MaxLength(81920)
+		cookie, ok := codec.(*securecookie.SecureCookie)
+		if !ok {
+			return nil, fmt.Errorf("unexpected codec type %T", codec)
+		}
+		cookie.MaxLength(maxSecureCookieLength)
 	}
-	return &CustomCookieStore{cookieStore}
+	return &CustomCookieStore{cookieStore}, nil
 }
 
 func (s *CustomCookieStore) Get(r *http.Request, name string) (*sessions.Session, error) {
 	return sessions.GetRegistry(r).Get(s, name)
 }
 
-// In contrast to default implementation, the session values can be partitioned into
+// New creates a session. In contrast to the default implementation, the session values can be partitioned into
 // multiple cookies.
-// The original cookie is split/joined in its encoded form
+// The original cookie is split/joined in its encoded form.
 func (s *CustomCookieStore) New(r *http.Request, name string) (*sessions.Session, error) {
 	session := sessions.NewSession(s, name)
 	opts := *s.Options
@@ -69,12 +76,11 @@ func (s *CustomCookieStore) New(r *http.Request, name string) (*sessions.Session
 	return session, err
 }
 
-// If the cookie length is > maxCookieLength, its value is split into multiple cookies
-// fitting into the maxCookieLength limit.
+// Save persists session values. If the cookie length is > maxCookieLength, its value is split
+// into multiple cookies fitting into the maxCookieLength limit.
 // The resulting section cookies get their index appended to the name.
 func (s *CustomCookieStore) Save(_ *http.Request, w http.ResponseWriter,
 	session *sessions.Session) error {
-
 	cookie, err := securecookie.EncodeMulti(session.Name(), session.Values,
 		s.Codecs...)
 	if err != nil {
@@ -98,26 +104,25 @@ func (s *CustomCookieStore) Save(_ *http.Request, w http.ResponseWriter,
 
 // joinCookies concatenates the values of all matching cookies and returns the original, encoded cookievalue string.
 func joinSectionCookies(r *http.Request, name string) string {
-
 	// Exact match without index means only a single cookie exists
 	if c, err := r.Cookie(name); err == nil {
 		return c.Value
 	}
 
-	var joinedValue string
+	var builder strings.Builder
 	for i := 0; true; i++ {
 		cookieName := buildSectionCookieName(name, i)
 		if c, err := r.Cookie(cookieName); err == nil {
-			joinedValue += c.Value
+			builder.WriteString(c.Value)
 		} else {
 			break
 		}
 	}
-	return joinedValue
+	return builder.String()
 }
 
 // splitCookie splits the original encoded cookie value into a slice of cookies which
-// fit within the 4kb cookie limit indexing the cookies from 0
+// fit within the 4kb cookie limit indexing the cookies from 0.
 func splitCookie(cookieValue string) []string {
 	var sectionCookies []string
 	valueBytes := []byte(cookieValue)

--- a/internal/session/store_test.go
+++ b/internal/session/store_test.go
@@ -26,32 +26,32 @@ import (
 )
 
 func TestJoinSectionCookies(t *testing.T) {
-	var originalValue string
+	var originalValue strings.Builder
 	var value string
 	cookies := buildRandomCookies(2, 3800, "test_%d")
 	buildRequestWithCookies(t, cookies, func(cookies []*http.Cookie, r *http.Request) {
 		for _, c := range cookies {
-			originalValue += c.Value
+			originalValue.WriteString(c.Value)
 		}
 		value = joinSectionCookies(r, "test")
 	})
-	if value != originalValue {
-		t.Errorf("joinSectionCookies value incorrect: \n value: %s \n originalValue: %s", value, originalValue)
+	if value != originalValue.String() {
+		t.Errorf("joinSectionCookies value incorrect: \n value: %s \n originalValue: %s", value, originalValue.String())
 	}
 }
 
 func TestJoinSectionCookiesSingle(t *testing.T) {
-	var originalValue string
+	var originalValue strings.Builder
 	var value string
 	cookies := buildRandomCookies(1, 2000, "test_%d")
 	buildRequestWithCookies(t, cookies, func(cookies []*http.Cookie, r *http.Request) {
 		for _, c := range cookies {
-			originalValue += c.Value
+			originalValue.WriteString(c.Value)
 		}
 		value = joinSectionCookies(r, "test")
 	})
-	if value != originalValue {
-		t.Errorf("joinSectionCookies value incorrect: \n value: %s \n originalValue: %s", value, originalValue)
+	if value != originalValue.String() {
+		t.Errorf("joinSectionCookies value incorrect: \n value: %s \n originalValue: %s", value, originalValue.String())
 	}
 }
 
@@ -104,12 +104,18 @@ func assertCookieOptions(t *testing.T, s *CustomCookieStore, wantSecure bool, wa
 }
 
 func TestNewCustomCookieStoreOptionsHTTPS(t *testing.T) {
-	s := NewCustomCookieStore(true, []byte("test-signing-key-32bytes!!"), []byte("test-encryption-key"))
+	s, err := NewCustomCookieStore(true, []byte("test-signing-key-32bytes!!"), []byte("test-encryption-key"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	assertCookieOptions(t, s, true, http.SameSiteLaxMode)
 }
 
 func TestNewCustomCookieStoreOptionsHTTP(t *testing.T) {
-	s := NewCustomCookieStore(false, []byte("test-signing-key-32bytes!!"), []byte("test-encryption-key"))
+	s, err := NewCustomCookieStore(false, []byte("test-signing-key-32bytes!!"), []byte("test-encryption-key"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	assertCookieOptions(t, s, false, http.SameSiteLaxMode)
 }
 
@@ -119,7 +125,7 @@ func TestSplitAndJoin(t *testing.T) {
 	sectionCookies := splitCookie(originalValue)
 	cookies := buildCookiesFromValues(sectionCookies, "test_%d")
 	var value string
-	buildRequestWithCookies(t, cookies, func(cookies []*http.Cookie, r *http.Request) {
+	buildRequestWithCookies(t, cookies, func(_ []*http.Cookie, r *http.Request) {
 		value = joinSectionCookies(r, "test")
 	})
 	if value != originalValue {
@@ -132,7 +138,7 @@ func TestSplitAndJoin(t *testing.T) {
 type handleReq func([]*http.Cookie, *http.Request)
 
 func buildRequestWithCookies(t *testing.T, cookies []*http.Cookie, fn handleReq) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		for _, cookie := range cookies {
 			r.AddCookie(cookie)
 		}
@@ -148,7 +154,7 @@ func buildRequestWithCookies(t *testing.T, cookies []*http.Cookie, fn handleReq)
 func buildRandomCookies(cookieCount int, cookieLength int, cookieName string) []*http.Cookie {
 	sessionOptions := &sessions.Options{}
 	var cookies []*http.Cookie
-	for i := 0; i < cookieCount; i++ {
+	for i := range cookieCount {
 		value := randStringBytesRmndr(cookieLength)
 		cookie := sessions.NewCookie(fmt.Sprintf(cookieName, i), value, sessionOptions)
 		cookies = append(cookies, cookie)

--- a/mise.toml
+++ b/mise.toml
@@ -28,6 +28,10 @@ golangci-lint = "2.11.4"
 description = "run golangci-lint"
 run = "golangci-lint run ./..."
 
+[tasks."lint-fix"]
+description = "run golangci-lint with autofix"
+run = "golangci-lint run --fix ./..."
+
 [tasks.test]
 description = "Run tests"
 run = "go test -count=1 -race ./..."

--- a/templates/commandline.tmpl
+++ b/templates/commandline.tmpl
@@ -100,7 +100,6 @@
                   <span class="euiCodeBlock__line">kubectl config set-context "{{ .ClusterName }}" --cluster="{{ .ClusterName }}" --user="{{ .KubeCfgUser }}" {{ if not (eq .Namespace "") }}--namespace="{{ .Namespace }}"{{ end }}</span>
                   <span class="euiCodeBlock__line">kubectl config use-context "{{ .ClusterName }}"</span>
                   {{ if not (eq .ClusterCA  "") }}<span class="euiCodeBlock__line">rm "ca-{{ .ClusterName }}.pem"</span>{{ end }}
-                  {{ if not (eq .IDPCA  "") }}<span class="euiCodeBlock__line">rm "ca-idp-{{ .ClusterName }}.pem"</span>{{ end }}
                 </code>
               </pre>
           </div>


### PR DESCRIPTION
### Summary 💡

This PR aims to address all lint findings and add a new checklist to the PR template.


### Description 📝

From 113 linting errors to 0. All lints resolved, with the exception of 'slog' (globally ignored) and 'testpackage' and 'gocognit' (ignored only in test files).

Notes:
- Added validation for custom filenames on download.
- Fixed Dex JWT validation: an error was planned but never caught. Additionally, the validation logic was corrected to use RSA instead of HMAC to match Dex's signing method.
- Added a new 'mise run lint-fix' command.
- Added a new section for code quality checks to the PR template.

### Breaking Changes 💔

Removed `TLS_RSA_WITH_AES_128_GCM_SHA256` and `TLS_RSA_WITH_AES_256_GCM_SHA384` from the allowed TLS cipher suites: only ECDHE-based cipher suites are now accepted, enforcing Perfect Forward Secrecy (PFS) on all connections.
This may affect legacy clients that do not support ECDHE key exchange (e.g., Java 6, Android 2.x, Windows XP). All modern TLS clients are unaffected.

### Tests performed 🧪

- [x] Executed `mise run test`.
- [x] Ran the local env and verified that all was working as expected.


### Future work 🔧

Not planned.