### PR TITLE
fix: release pipeline regressions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,21 +88,25 @@ dockers:
 
 docker_manifests:
   - name_template: registry.sighup.io/fury/gangplank:latest
+    skip_push: auto
     image_templates:
       - registry.sighup.io/fury/gangplank-amd64:latest
       - registry.sighup.io/fury/gangplank-arm64:latest
 
   - name_template: registry.sighup.io/fury/gangplank:{{ .Major }}
+    skip_push: auto
     image_templates:
       - registry.sighup.io/fury/gangplank-amd64:{{ .Major }}
       - registry.sighup.io/fury/gangplank-arm64:{{ .Major }}
 
   - name_template: registry.sighup.io/fury/gangplank:{{ .Major }}.{{ .Minor }}
+    skip_push: auto
     image_templates:
       - registry.sighup.io/fury/gangplank-amd64:{{ .Major }}.{{ .Minor }}
       - registry.sighup.io/fury/gangplank-arm64:{{ .Major }}.{{ .Minor }}
 
   - name_template: registry.sighup.io/fury/gangplank:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+    skip_push: auto
     image_templates:
       - registry.sighup.io/fury/gangplank-amd64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}
       - registry.sighup.io/fury/gangplank-arm64:{{ .Major }}.{{ .Minor }}.{{ .Patch }}

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,7 @@ ctlptl = "0.9.3"
 helm = "4.1.4"
 kind = "0.31.0"
 golangci-lint = "2.11.4"
-cosign = "2.6.3"
+cosign = "3.0.6"
 "go:github.com/google/addlicense" = "v1.1.1"
 
 [tasks.lint]

--- a/mise.toml
+++ b/mise.toml
@@ -22,6 +22,7 @@ ctlptl = "0.9.3"
 helm = "4.1.4"
 kind = "0.31.0"
 golangci-lint = "2.11.4"
+cosign = "2.6.3"
 "go:github.com/google/addlicense" = "v1.1.1"
 
 [tasks.lint]


### PR DESCRIPTION
Fix two release regressions introduced with the mise migration:
- skip floating-tag docker manifests on pre-release (mirroring the existing skip_push: auto on the docker entries)
- add cosign to mise-managed tools so image signing works in CI.

Tests:
- [x] CI passed https://ci.sighup.io/sighupio/gangplank/152 