### PR TITLE
change state string generation

### DIFF
--- a/cmd/gangplank/handlers.go
+++ b/cmd/gangplank/handlers.go
@@ -21,7 +21,6 @@ import (
 	htmltemplate "html/template"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,7 +179,7 @@ func (s *server) loginHandler(w http.ResponseWriter, r *http.Request) {
 	b := make([]byte, stateTokenBytes)
 	// From the rand.Read signature: It never returns an error, and always fills b entirely.
 	_, _ = rand.Read(b)
-	state := url.QueryEscape(base64.StdEncoding.EncodeToString(b))
+	state := base64.RawURLEncoding.EncodeToString(b)
 
 	session, err := s.gangplankUserSession.Session.Get(r, "gangplank")
 	if err != nil {


### PR DESCRIPTION
### Summary 💡

Change the generation of the state string, so that it does not include any non URL safe characters 

### Description 📝

I changed the way how the state string was generated away from `state := url.QueryEscape(base64.StdEncoding.EncodeToString(b))` to `state := base64.RawURLEncoding.EncodeToString(b)` because an IDP I need to use removes the query escaped chars which led to a state mismatch on the callback. My change generates a url safe string and mitigates this problem.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Local Verification: Validated functionality within the local development environment.
- [x] Verification agains different IDPs


### Code quality 🧾

- [x] Executed tests with `mise run test`
- [x] Checked lint with `mise run lint`
- [x] Checked license with `mise run license-check`

### Future work 🔧

None